### PR TITLE
add mapping of mob prefabs to config item names

### DIFF
--- a/lib/const.lua
+++ b/lib/const.lua
@@ -30,6 +30,23 @@ M.ANNOUNCE_MOBS = {
     "toadstool", "walrus", "warg"
 }
 
+M.ANNOUNCE_MOBS_TO_CONFIG_NAME_MAP = {
+    alterguardian_phase1 = "alterguardian",
+    alterguardian_phase2 = "alterguardian",
+    alterguardian_phase3 = "alterguardian",
+    deciduoustree = "treeguard",
+    leif = "treeguard",
+    leif_sparse = "treeguard",
+    koalefant_summer = "koalefant",
+    koalefant_winter = "koalefant",
+    shadow_bishop = "shadowchesspieces",
+    shadow_knight = "shadowchesspieces",
+    shadow_rook = "shadowchesspieces",
+    stalker_atrium = "stalker",
+    stalker_forest = "stalker",
+    toadstool_dark = "toadstool"
+}
+
 -- URLs to small images to use as an avatar in Discord messages
 M.CHARACTER_ICON = {
     unknown = "https://media.discordapp.net/attachments/879978511203463179/881557033411829760/avatar_unknown.png",

--- a/modmain.lua
+++ b/modmain.lua
@@ -25,14 +25,20 @@ local INCLUDE_DEATH_LOCATION = GetModConfigData("include_death_location")
 local webhook_url = nil
 local webhook_name = nil
 
+local function getConfigNameForPrefab(prefab)
+  return C.ANNOUNCE_MOBS_TO_CONFIG_NAME_MAP[prefab] or prefab
+end
+
 -- obtain effective announcement flags for a prefab, considering a possible "DEFAULT" setting
 local function getAnnounceChannels(prefab, event)
+  -- map multiple prefab variants to single config name, f. ex. koalefant_summer/_winter to just koalefant
+  local config_name = getConfigNameForPrefab(prefab) or prefab
   -- get individual setting of prefab for event
-  local prefab_setting = GetModConfigData(event.."_"..prefab) or C.AnnounceChannelEnum.DISABLED
+  local prefab_setting = GetModConfigData(tostring(event).."_"..tostring(config_name)) or C.AnnounceChannelEnum.DISABLED
 
   -- if individual setting is DEFAULT, set it to the global event default setting
   if util.FlagIsSet(C.AnnounceChannelEnum.DEFAULT, prefab_setting) then
-    prefab_setting = GetModConfigData("announce_"..event) or C.AnnounceChannelEnum.DISABLED
+    prefab_setting = GetModConfigData("announce_"..tostring(event)) or C.AnnounceChannelEnum.DISABLED
   end
   return prefab_setting
 end


### PR DESCRIPTION
Several mobs exist in variants (f. ex. treeguards, shadow chesspieces,
koalafant), but the mod configuration does not differentiate currently
to keep the config a bit leaner. When getting the configuration settings
for a specific mob, a map has been introduced to look up the config
item name for prefabs, where the prefab isn't identical to the config
item name.

Fixes #2.

Signed-off-by: Dennis Herbrich <kontakt+github@veloxis.de>