### PR TITLE
Version 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Table of Contents
     - [Graphics](#graphics)
     - [Source Code](#source-code)
   - [Changelog](#changelog)
+    - [Version 1.1.1 (2021-09-16)](#version-111-2021-09-16)
     - [Version 1.1.0 (2021-09-11)](#version-110-2021-09-11)
     - [Version 1.0.0 (2021-09-06)](#version-100-2021-09-06)
 
@@ -176,7 +177,29 @@ Discord webhook handling and setup a notch in terms of error checking.
 Changelog
 ---------
 
+### Version 1.1.1 (2021-09-16)
+  **Bugfixes**
+  - fix missing mob death announcements (*Gyroplast*)
+
+    Several mob deaths were mistakenly not announced at all:
+    - Celestial Champion
+    - all three treeguard variants
+    - Summer and Winter Koalefant
+    - all shadow chesspieces
+    - both stalker variants
+    - Misery Toadstool
+
+    This is now fixed by mapping the lookup for the announcement configuration to the correct prefab names.
+    Thanks go to CampbellSoupBoy for reporting!
+
+    Fixes [#2](https://github.com/gyroplast/mod-dont-starve-chat-announcements/issues/2).
+  - fix package script to prevent symlink loops
+
+  **Other Changes**
+  - change MOD_DEBUG bool to LOGLEVEL implementation, add TRACE
+  - handle non-string inputs with trim() and starts_with()
 ### Version 1.1.0 (2021-09-11)
+  **New Features**
   - add Steam Workshop ID to mod description (*Gyroplast*)
   - use last attacker in 5 secs in player death announcement (*Gyroplast*)
     

--- a/lib/const.lua
+++ b/lib/const.lua
@@ -1,8 +1,11 @@
 -- useful constants
 local M = {}
 
--- set to true to generate more debugging log output
-M.MOD_DEBUG = false
+-- available log levels in increasing severity
+M.LOGLEVEL = { TRACE = 1, DEBUG = 2, INFO = 3, WARN = 4, WARNING = 4, ERR = 5, ERROR = 5 }
+
+-- set to intended loglevel threshold
+M.MOD_LOGLEVEL = M.LOGLEVEL.TRACE
 
 -- URI of source and documentation distribution
 M.SRC_URL = modinfo._src_url

--- a/lib/const.lua
+++ b/lib/const.lua
@@ -5,7 +5,7 @@ local M = {}
 M.LOGLEVEL = { TRACE = 1, DEBUG = 2, INFO = 3, WARN = 4, WARNING = 4, ERR = 5, ERROR = 5 }
 
 -- set to intended loglevel threshold
-M.MOD_LOGLEVEL = M.LOGLEVEL.TRACE
+M.MOD_LOGLEVEL = M.LOGLEVEL.INFO
 
 -- URI of source and documentation distribution
 M.SRC_URL = modinfo._src_url

--- a/lib/logging.lua
+++ b/lib/logging.lua
@@ -3,26 +3,39 @@ local M = {}
 
 local Logging = Class()
 
+-- log formatted TRACE message to stdout, prefixed with verbose modname.
+function Logging:Trace(msg, ...)
+  if C.MOD_LOGLEVEL <= C.LOGLEVEL.TRACE then
+    print(string.format("Mod: %s\t[TRACE] "..msg, C.LONG_MODNAME, ...))
+  end
+end
+
 -- log formatted DEBUG message to stdout, prefixed with verbose modname.
 function Logging:Debug(msg, ...)
-  if C.MOD_DEBUG then
+  if C.MOD_LOGLEVEL <= C.LOGLEVEL.DEBUG then
     print(string.format("Mod: %s\t[DEBUG] "..msg, C.LONG_MODNAME, ...))
   end
 end
 
 -- log formatted INFO message to stdout, prefixed with verbose modname.
 function Logging:Info(msg, ...)
-  print(string.format("Mod: %s\t[INFO ] "..msg, C.LONG_MODNAME, ...))
+  if C.MOD_LOGLEVEL <= C.LOGLEVEL.INFO then
+    print(string.format("Mod: %s\t[INFO ] "..msg, C.LONG_MODNAME, ...))
+  end
 end
 
 -- log formatted WARNING message to stdout, prefixed with verbose modname.
 function Logging:Warn(msg, ...)
-  print(string.format("Mod: %s\t[WARN ] "..msg, C.LONG_MODNAME, ...))
+  if C.MOD_LOGLEVEL <= C.LOGLEVEL.WARN then
+    print(string.format("Mod: %s\t[WARN ] "..msg, C.LONG_MODNAME, ...))
+  end
 end
 
 -- log critical, unrecoverable ERROR and exit mod.
 function Logging:Error(msg, ...)
-  moderror(msg)
+  if C.MOD_LOGLEVEL <= C.LOGLEVEL.ERROR then
+    moderror(msg)
+  end
 end
 
 -- exports

--- a/lib/util.lua
+++ b/lib/util.lua
@@ -3,7 +3,7 @@ local M = {}
 local json = require("json")
 
 -- remove leading and trailing whitespace from a string
-function M.trim(s) return s:gsub("^%s*(.-)%s*$", "%1") end
+function M.trim(s) return (type(s) == "string" and s:gsub("^%s*(.-)%s*$", "%1") or "") end
 
 -- round a number to the nearest decimal places
 function M.round(val, decimal)
@@ -18,7 +18,7 @@ end
 function M.FlagIsSet(flag, value) return (value / flag) % 2 >= 1 end
 
 -- return true iff str starts with start, without other preceding characters
-function M.starts_with(str, start) return str:sub(1, #start) == start end
+function M.starts_with(str, start) return (type(str) == "string" and (str:sub(1, #start) == start) or false) end
 
 -- pretty-print table only one level deep
 function M.table2str(t)

--- a/modinfo.lua
+++ b/modinfo.lua
@@ -5,7 +5,7 @@ _src_url = "https://github.com/gyroplast/mod-dont-starve-chat-announcements"
 
 name = "Chat Announcements"
 author = "Gyroplast"
-version = "1.1.0"
+version = "1.1.1"
 forumthread = "/profile/631156-gyroplast/"
 api_version = 10
 dont_starve_compatible = false

--- a/modmain.lua
+++ b/modmain.lua
@@ -197,7 +197,7 @@ local function health_override(inst)
 
       if inst and cause ~= "oldager_component" then
         inst.CA_lasthit = { amount = amount, cause = cause, afflicter = afflicter, time = _G.GetTime() }
-        Log:Debug("lasthit info: "..util.table2str(inst.CA_lasthit))
+        Log:Trace("lasthit info: "..util.table2str(inst.CA_lasthit))
       end
       f(...)
     end
@@ -224,18 +224,18 @@ local function death_handler(inst)
     local last_attacker = inst.components and inst.components.combat and inst.components.combat.lastattacker or nil
     local last_attacked_time = inst.components and inst.components.combat and inst.components.combat.lastwasattackedtime or 0
 
-    Log:Debug("death_handler dmg info: "..util.table2str({lasthit=util.table2str(lasthit), last_attacker=last_attacker, last_attacked_time=last_attacked_time, gettime=_G.GetTime()}))
+    Log:Trace("death_handler dmg info: "..util.table2str({lasthit=util.table2str(lasthit), last_attacker=last_attacker, last_attacked_time=last_attacked_time, gettime=_G.GetTime()}))
     if last_attacker and _G.GetTime() < last_attacked_time + 5 then
       data.afflicter = last_attacker or data.afflicter
       data.cause = tostring(last_attacker.prefab)
-      Log:Debug(string.format("death_handler setting last attacker afflicter %s, cause %s",
+      Log:Trace(string.format("death_handler setting last attacker afflicter %s, cause %s",
         tostring(data.afflicter),
         tostring(data.cause)
       ))
     elseif data.cause == "oldager_component" and lasthit and _G.GetTime() < lasthit.time + 5 then
       data.afflicter = lasthit.afflicter or data.afflicter
       data.cause = lasthit.afflicter and tostring(lasthit.afflicter.prefab) or (lasthit.cause and lasthit.cause or data.cause)
-      Log:Debug(string.format("death_handler setting last hit afflicter %s, cause %s",
+      Log:Trace(string.format("death_handler setting last hit afflicter %s, cause %s",
         tostring(data.afflicter),
         tostring(data.cause)
       ))

--- a/package.sh
+++ b/package.sh
@@ -3,9 +3,10 @@ set -e
 set -x
 _modname=$(sed -n '/^\s*name\s*=/{s/.*"\(.\+\).*"/\1/p;q}' modinfo.lua)
 _modversion=$(sed -n '/^\s*version\s*=/{s/.*"\(.\+\).*"/\1/p;q}' modinfo.lua)
-_OUT=$(readlink -m -n "./out/${_modname// /_}-${_modversion}")
-_OUTSTEAM=$(readlink -m -n "./out/steam/${_modname// /_}")
-rm -fr "${_OUT}" "${_OUT}.zip"
+_OUT="./out/${_modname// /_}-${_modversion}"
+_OUTSTEAM="./out/steam/${_modname// /_}"
+
+rm -fr "${_OUT}" "${_OUTSTEAM}" "${_OUT}.zip"
 
 for f in README.md LICENSE modicon.* modinfo.lua modmain.lua lib/*; do
   install -Dm755 "$f" "${_OUT}/${f}"
@@ -13,8 +14,8 @@ done
 
 # the ModUploader REALLY wants the mod to be in this subdirectory
 install -dm755 "$(dirname "${_OUTSTEAM}")"
-ln -sf "${_OUT}" "${_OUTSTEAM}"
+ln -rsf "${_OUT}" "${_OUTSTEAM}"
 
 pushd "${_OUT}"/..
-zip -r9 "${_OUT}.zip" "$(basename "${_OUT}")"
+zip -r9 "$(basename "${_OUT}")"{.zip,}
 popd

--- a/package.sh
+++ b/package.sh
@@ -3,12 +3,17 @@ set -e
 set -x
 _modname=$(sed -n '/^\s*name\s*=/{s/.*"\(.\+\).*"/\1/p;q}' modinfo.lua)
 _modversion=$(sed -n '/^\s*version\s*=/{s/.*"\(.\+\).*"/\1/p;q}' modinfo.lua)
-_OUT=$(readlink -m -n "./out/${_modname}-${_modversion}")
+_OUT=$(readlink -m -n "./out/${_modname// /_}-${_modversion}")
+_OUTSTEAM=$(readlink -m -n "./out/steam/${_modname// /_}")
 rm -fr "${_OUT}" "${_OUT}.zip"
 
 for f in README.md LICENSE modicon.* modinfo.lua modmain.lua lib/*; do
   install -Dm755 "$f" "${_OUT}/${f}"
 done
+
+# the ModUploader REALLY wants the mod to be in this subdirectory
+install -dm755 "$(dirname "${_OUTSTEAM}")"
+ln -sf "${_OUT}" "${_OUTSTEAM}"
 
 pushd "${_OUT}"/..
 zip -r9 "${_OUT}.zip" "$(basename "${_OUT}")"


### PR DESCRIPTION
  **Bugfixes**
  - fix missing mob death announcements (*Gyroplast*)

    Several mob deaths were mistakenly not announced at all:
    - Celestial Champion
    - all three treeguard variants
    - Summer and Winter Koalefant
    - all shadow chesspieces
    - both stalker variants
    - Misery Toadstool

    This is now fixed by mapping the lookup for the announcement
    configuration to the correct prefab names.
    Thanks go to CampbellSoupBoy for reporting!

    Fixes #2.
  - fix package script to prevent symlink loops

  **Other Changes**
  - change MOD_DEBUG bool to LOGLEVEL implementation, add TRACE
  - handle non-string inputs with trim() and starts_with()